### PR TITLE
Fixed eosio.cdt link in CICD

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "develop",
-            "eosio.cdt": "release/1.7.x"
+            "eosio.cdt": "1333c50ee50a3dcaf4619d53ed6932d4513637c5"
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
#### Github Action error: 
 `curl: (22) The requested URL returned error: 404 Not Found
ERROR: Expected CDT binary for commit 6694d477cb4e7072eced0820981646aad3438883 from release/1.7.x. It does not exist at https://eos-public-oss-binaries.s3-us-west-2.amazonaws.com/6694d47-eosio.cdt-ubuntu-18.04_amd64.deb!
There must be a successful build against 6694d477cb4e7072eced0820981646aad3438883 ]1339;url=https://buildkite.com/EOSIO/eosio-dot-cdt/builds?commit=6694d477cb4e7072eced0820981646aad3438883;content=here for this package to exist.` 